### PR TITLE
Fix ImagePickerActivity Opening Gallery or Camera Twice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.70'
     repositories {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         //jcenter plugins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 07 23:33:12 IST 2019
+#Sun Mar 08 16:57:13 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "../ktlint.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 7
         versionName "1.6"
 

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -78,7 +78,7 @@ class ImagePickerActivity : AppCompatActivity() {
      * Save all appropriate activity state.
      */
     public override fun onSaveInstanceState(outState: Bundle) {
-        outState.putSerializable(STATE_CROP_STARTED, mStartedCropActivity)
+        outState.putSerializable(STATE_CROP_STARTED, true)
         outState.putSerializable(STATE_IMAGE_FILE, mImageFile)
         mCameraProvider?.onSaveInstanceState(outState)
         mCropProvider.onSaveInstanceState(outState)
@@ -168,13 +168,6 @@ class ImagePickerActivity : AppCompatActivity() {
             mCompressionProvider.isCompressionRequired(file) -> mCompressionProvider.compress(file)
             else -> setResult(file)
         }
-    }
-
-    /**
-     * Called by CropProvider.cropImage to indicate that the Crop Activity started.
-     */
-    fun cropStarted() {
-        mStartedCropActivity = true
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import com.github.dhaval2404.imagepicker.constant.ImageProvider
 import com.github.dhaval2404.imagepicker.provider.CameraProvider
 import com.github.dhaval2404.imagepicker.provider.CompressionProvider
@@ -97,9 +98,10 @@ class ImagePickerActivity : AppCompatActivity() {
         mCompressionProvider = CompressionProvider(this)
 
         // If crop already started, don't start the Gallery/Camera activity again
-        if(mStartedCropActivity) {
-            return
-        }
+
+        var callingActivityName = callingActivity?.className
+        var referrer = ActivityCompat.getReferrer(this)
+        var test = referrer.toString()
 
         // Retrieve Image Provider
         val provider: ImageProvider? =

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -33,9 +33,9 @@ class ImagePickerActivity : AppCompatActivity() {
         private const val STATE_IMAGE_FILE = "state.image_file"
 
         /**
-         * Key to Save/Retrieve Crop state
+         * Indicates that the Crop activity started
          */
-        private const val STATE_CROP_STARTED = "state.crop_started"
+        var CROP_STARTED = false
 
         internal fun getCancelledIntent(context: Context): Intent {
             val intent = Intent()
@@ -56,9 +56,6 @@ class ImagePickerActivity : AppCompatActivity() {
     /** File provided by CropProvider */
     private var mCropFile: File? = null
 
-    /** CropProvider started the Crop Activity*/
-    private var mStartedCropActivity: Boolean = false
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         restoreInstanceState(savedInstanceState)
@@ -70,7 +67,6 @@ class ImagePickerActivity : AppCompatActivity() {
      */
     private fun restoreInstanceState(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
-            mStartedCropActivity = savedInstanceState.getSerializable(STATE_CROP_STARTED) as Boolean
             mImageFile = savedInstanceState.getSerializable(STATE_IMAGE_FILE) as File?
         }
     }
@@ -79,7 +75,6 @@ class ImagePickerActivity : AppCompatActivity() {
      * Save all appropriate activity state.
      */
     public override fun onSaveInstanceState(outState: Bundle) {
-        outState.putSerializable(STATE_CROP_STARTED, true)
         outState.putSerializable(STATE_IMAGE_FILE, mImageFile)
         mCameraProvider?.onSaveInstanceState(outState)
         mCropProvider.onSaveInstanceState(outState)
@@ -98,10 +93,9 @@ class ImagePickerActivity : AppCompatActivity() {
         mCompressionProvider = CompressionProvider(this)
 
         // If crop already started, don't start the Gallery/Camera activity again
-
-        var callingActivityName = callingActivity?.className
-        var referrer = ActivityCompat.getReferrer(this)
-        var test = referrer.toString()
+        if(CROP_STARTED) {
+            return
+        }
 
         // Retrieve Image Provider
         val provider: ImageProvider? =
@@ -222,6 +216,7 @@ class ImagePickerActivity : AppCompatActivity() {
      * @param file final image file
      */
     private fun setResult(file: File) {
+        CROP_STARTED = false
         val intent = Intent()
         intent.data = Uri.fromFile(file)
         intent.putExtra(ImagePicker.EXTRA_FILE_PATH, file.absolutePath)
@@ -233,6 +228,7 @@ class ImagePickerActivity : AppCompatActivity() {
      * User has cancelled the task
      */
     fun setResultCancel() {
+        CROP_STARTED = false
         setResult(Activity.RESULT_CANCELED, getCancelledIntent(this))
         finish()
     }
@@ -243,6 +239,7 @@ class ImagePickerActivity : AppCompatActivity() {
      * @param message Error Message
      */
     fun setError(message: String) {
+        CROP_STARTED = false
         val intent = Intent()
         intent.putExtra(ImagePicker.EXTRA_ERROR, message)
         setResult(ImagePicker.RESULT_ERROR, intent)

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -58,8 +58,15 @@ class ImagePickerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        restoreInstanceState(savedInstanceState)
-        loadBundle(savedInstanceState)
+
+        // If crop already started, don't start the Gallery/Camera activity again
+        if(CROP_STARTED) {
+            finish()
+        }
+        else {
+            restoreInstanceState(savedInstanceState)
+            loadBundle(savedInstanceState)
+        }
     }
 
     /**
@@ -91,11 +98,6 @@ class ImagePickerActivity : AppCompatActivity() {
 
         // Create Compression Provider
         mCompressionProvider = CompressionProvider(this)
-
-        // If crop already started, don't start the Gallery/Camera activity again
-        if(CROP_STARTED) {
-            return
-        }
 
         // Retrieve Image Provider
         val provider: ImageProvider? =

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -171,6 +171,13 @@ class ImagePickerActivity : AppCompatActivity() {
     }
 
     /**
+     * Called by CropProvider.cropImage to indicate that the Crop Activity started.
+     */
+    fun cropStarted() {
+        mStartedCropActivity = true
+    }
+
+    /**
      * {@link CropProviders} Result will be available here.
      *
      * Check if compression is enable/required. If yes then start compression else return result.

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePickerActivity.kt
@@ -31,6 +31,11 @@ class ImagePickerActivity : AppCompatActivity() {
          */
         private const val STATE_IMAGE_FILE = "state.image_file"
 
+        /**
+         * Key to Save/Retrieve Crop state
+         */
+        private const val STATE_CROP_STARTED = "state.crop_started"
+
         internal fun getCancelledIntent(context: Context): Intent {
             val intent = Intent()
             val message = context.getString(R.string.error_task_cancelled)
@@ -50,6 +55,9 @@ class ImagePickerActivity : AppCompatActivity() {
     /** File provided by CropProvider */
     private var mCropFile: File? = null
 
+    /** CropProvider started the Crop Activity*/
+    private var mStartedCropActivity: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         restoreInstanceState(savedInstanceState)
@@ -61,6 +69,7 @@ class ImagePickerActivity : AppCompatActivity() {
      */
     private fun restoreInstanceState(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
+            mStartedCropActivity = savedInstanceState.getSerializable(STATE_CROP_STARTED) as Boolean
             mImageFile = savedInstanceState.getSerializable(STATE_IMAGE_FILE) as File?
         }
     }
@@ -69,6 +78,7 @@ class ImagePickerActivity : AppCompatActivity() {
      * Save all appropriate activity state.
      */
     public override fun onSaveInstanceState(outState: Bundle) {
+        outState.putSerializable(STATE_CROP_STARTED, mStartedCropActivity)
         outState.putSerializable(STATE_IMAGE_FILE, mImageFile)
         mCameraProvider?.onSaveInstanceState(outState)
         mCropProvider.onSaveInstanceState(outState)
@@ -85,6 +95,11 @@ class ImagePickerActivity : AppCompatActivity() {
 
         // Create Compression Provider
         mCompressionProvider = CompressionProvider(this)
+
+        // If crop already started, don't start the Gallery/Camera activity again
+        if(mStartedCropActivity) {
+            return
+        }
 
         // Retrieve Image Provider
         val provider: ImageProvider? =

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -117,8 +117,6 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         }
 
         try {
-            activity.cropStarted()
-            activity.onSaveInstanceState(Bundle())
             uCrop.start(activity, UCrop.REQUEST_CROP)
         } catch (ex: ActivityNotFoundException) {
             setError(

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -117,6 +117,7 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         }
 
         try {
+            ImagePickerActivity.CROP_STARTED = true
             uCrop.start(activity, UCrop.REQUEST_CROP)
         } catch (ex: ActivityNotFoundException) {
             setError(
@@ -140,6 +141,7 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      */
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == UCrop.REQUEST_CROP) {
+            ImagePickerActivity.CROP_STARTED = false
             if (resultCode == Activity.RESULT_OK) {
                 handleResult(mCropImageFile)
             } else {

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -117,7 +117,7 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         }
 
         try {
-            activity.setCropImage(file)
+            activity.cropStarted()
             uCrop.start(activity, UCrop.REQUEST_CROP)
         } catch (ex: ActivityNotFoundException) {
             setError(

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -118,6 +118,7 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
 
         try {
             activity.cropStarted()
+            activity.onSaveInstanceState(Bundle())
             uCrop.start(activity, UCrop.REQUEST_CROP)
         } catch (ex: ActivityNotFoundException) {
             setError(

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -117,6 +117,7 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         }
 
         try {
+            activity.setCropImage(file)
             uCrop.start(activity, UCrop.REQUEST_CROP)
         } catch (ex: ActivityNotFoundException) {
             setError(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "../ktlint.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.github.dhaval2404.imagepicker.sample"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 7
         versionName "1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.github.dhaval2404.imagepicker.sample">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="true"
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:targetApi="q">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
- Fix ImagePickerActivity where when crop is enabled AND using start() with the completionHandler, the gallery or camera app opens again after a photo is selected/confirmed.

```kotlin
 ImagePicker.with(this)
                    .provider(ImageProvider.GALLERY)
                    .crop(3f, 4f)
                    .maxResultSize(150, 200)
                    .compress(500)
                    .start { resultCode, data ->
                        when (resultCode) {
                            Activity.RESULT_OK -> {
                               
                            }
                        }
                    }
```