### PR TITLE
Android Activity Result APIs (full - removed InlineActivityResult)

### DIFF
--- a/.idea/$CACHE_FILE$
+++ b/.idea/$CACHE_FILE$
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id />
+          </State>
+          <State>
+            <id>Android</id>
+          </State>
+          <State>
+            <id>Android &gt; Lint &gt; Correctness</id>
+          </State>
+          <State>
+            <id>Android &gt; Lint &gt; Correctness &gt; Messages</id>
+          </State>
+          <State>
+            <id>Android &gt; Lint &gt; Performance</id>
+          </State>
+          <State>
+            <id>CorrectnessLintAndroid</id>
+          </State>
+          <State>
+            <id>General</id>
+          </State>
+          <State>
+            <id>Groovy</id>
+          </State>
+          <State>
+            <id>Java</id>
+          </State>
+          <State>
+            <id>LintAndroid</id>
+          </State>
+          <State>
+            <id>Numeric issuesJava</id>
+          </State>
+          <State>
+            <id>Potentially confusing code constructsGroovy</id>
+          </State>
+          <State>
+            <id>Threading issuesJava</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>Android</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <wildcardResourcePatterns>
+      <entry name="!?*.java" />
+      <entry name="!?*.form" />
+      <entry name="!?*.class" />
+      <entry name="!?*.groovy" />
+      <entry name="!?*.scala" />
+      <entry name="!?*.flex" />
+      <entry name="!?*.kt" />
+      <entry name="!?*.clj" />
+    </wildcardResourcePatterns>
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="MarkdownUnresolvedFileReference" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ See the original repository README [here](https://github.com/Dhaval2404/ImagePic
 
 # Changelog
 
-## Fork 1.0.0
+## Fork 1.9.0
 - Added [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result)

--- a/README.md
+++ b/README.md
@@ -30,5 +30,11 @@ See the original repository README [here](https://github.com/Dhaval2404/ImagePic
 
 # Changelog
 
+## Fork 1.9.1
+- Removed all startForActivityResult from library since caller is responsible to provide an `ActivityResultLauncher<Intent>`
+- Removed https://github.com/florent37/InlineActivityResult dependency
+
+---
+
 ## Fork 1.9.0
 - Added [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ See the original repository README [here](https://github.com/Dhaval2404/ImagePic
 
 # Changelog
 
-## Fork 1.2.0
-- Removed https://github.com/florent37/InlineActivityResult dependency
-
 ---
 
 ## Fork 1.0.0

--- a/README.md
+++ b/README.md
@@ -30,7 +30,5 @@ See the original repository README [here](https://github.com/Dhaval2404/ImagePic
 
 # Changelog
 
----
-
 ## Fork 1.0.0
 - Added [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the original repository README [here](https://github.com/Dhaval2404/ImagePic
 # Changelog
 
 ## Fork 1.9.1
-- Removed all startForActivityResult from library since caller is responsible to provide an `ActivityResultLauncher<Intent>`
+- Removed all `sstartActivityForResult` from library since caller is responsible to provide an `ActivityResultLauncher<Intent>`
 - Removed https://github.com/florent37/InlineActivityResult dependency
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,363 +1,39 @@
-# 📸Image Picker Library for Android
+# About this Fork
 
-[![Download](https://api.bintray.com/packages/dhaval2404/maven/imagepicker/images/download.svg) ](https://bintray.com/dhaval2404/maven/imagepicker/_latestVersion) 
-[![Releases](https://img.shields.io/github/release/dhaval2404/imagePicker/all.svg?style=flat-square)](https://github.com/Dhaval2404/ImagePicker/releases)
-[![API](https://img.shields.io/badge/API-19%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=19)
-![Language](https://img.shields.io/badge/language-Kotlin-orange.svg)
-[![Android Arsenal]( https://img.shields.io/badge/Android%20Arsenal-ImagePicker-green.svg?style=flat )]( https://android-arsenal.com/details/1/7510 )
-[![PRWelcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Dhaval2404/ImagePicker)
-[![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/Dhaval2404)
-[![Twitter](https://img.shields.io/twitter/url/https/github.com/Dhaval2404/ImagePicker.svg?style=social)](https://twitter.com/intent/tweet?text=Check+out+an+ImagePicker+library+to+Pick+an+image+from+the+Gallery+or+Capture+an+image+with+Camera.+https%3A%2F%2Fgithub.com%2FDhaval2404%2FImagePicker+%40dhaval2404+%23Android+%23Kotlin+%23AndroidDev)
+I've forked this project to migrate to new [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result).
 
-<div align="center">
-  <sub>Built with ❤︎ by
-  <a href="https://twitter.com/Dhaval2404">Dhaval Patel</a> and
-  <a href="https://github.com/dhaval2404/imagepicker/graphs/contributors">
-    contributors
-  </a>
-</div>
-<br/>
-
-Easy to use and configurable library to **Pick an image from the Gallery or Capture image using Camera**. It also allows to **Crop and Compresses the Image based on Aspect Ratio, Resolution and Image Size**.
-
-Almost 90% of the app that I have developed has an Image upload feature. Along with the image selection, Sometimes  I needed a crop feature for profile image for that I've used uCrop. Most of the time I need to compress the image as the image captured from the camera is more than 5-10 MBs and sometimes we have a requirement to upload images with specific resolution/size, in that case, image compress is the way to go option. To simplify the image pick/capture option I have created ImagePicker library. I hope it will be useful to all.
-
-# 🐱‍🏍Features:
-	
-* Pick Gallery Image
-* Pick Image from Google Drive
-* Capture Camera Image
-* Crop Image(Crop image based on provided aspect ratio or let user choose one)
-* Compress Image(Compress image based on provided resolution and size)
-* Retrieve Image Result as File, File Path as String or Uri object
-* Handle Runtime Permission for Camera and Storage
-
-# 🎬Preview
-
-
-   Profile Image Picker    |         Gallery Only      |       Camera Only        |
-:-------------------------:|:-------------------------:|:-------------------------:
-![](https://github.com/Dhaval2404/ImagePicker/blob/master/art/imagepicker_profile_demo.gif)  |  ![](https://github.com/Dhaval2404/ImagePicker/blob/master/art/imagepicker_gallery_demo.gif.gif)  |  ![](https://github.com/Dhaval2404/ImagePicker/blob/master/art/imagepicker_camera_demo.gif.gif)
-
-# 💻Usage
-
-
-1. Gradle dependency:
-
-	```groovy
-	allprojects {
-	   repositories {
-	      	jcenter()
-           	maven { url "https://jitpack.io" }  //Make sure to add this in your project for uCrop
-	   }
-	}
-	```
-
-    ```groovy
-   implementation 'com.github.dhaval2404:imagepicker:1.8'
-    ```
-    
-   **If you are yet to Migrate on AndroidX, Use support build artifact:**
-   ```groovy
-   implementation 'com.github.dhaval2404:imagepicker-support:1.7.1'
-    ```
-
-    **If you want to get the activity result inline in a modern way (lambda) install [InlineActivityResult](https://github.com/florent37/InlineActivityResult) library:**
-   ```groovy
-   implementation 'com.github.florent37:inline-activity-result-kotlin:1.0.4'
-    ```
-    
-2.  <span style="color:red">**If you target Android 10 or higher(targetSdkVersion >= 29)**</span>, set the value of ``requestLegacyExternalStorage`` to true in your app's manifest file:
-
-      ```xml
-    <manifest ... >
-          <!-- This attribute is "false" by default on apps targeting
-               Android 10 or higher. -->
-          <application android:requestLegacyExternalStorage="true" ... >
-            ...
-          </application>
-    </manifest>
-      ```
-
-3. The ImagePicker configuration is created using the builder pattern.
-
-	**Kotlin**
-    
-	```kotlin
-    ImagePicker.with(this)
-            .crop()	    			//Crop image(Optional), Check Customization for more option
-            .compress(1024)			//Final image size will be less than 1 MB(Optional)
-            .maxResultSize(1080, 1080)	//Final image resolution will be less than 1080 x 1080(Optional)
-            .start()
-    ```
-    
-    **Java**
-    
-    ```kotlin
-    ImagePicker.Companion.with(this)
-            .crop()	    			//Crop image(Optional), Check Customization for more option
-            .compress(1024)			//Final image size will be less than 1 MB(Optional)
-            .maxResultSize(1080, 1080)	//Final image resolution will be less than 1080 x 1080(Optional)
-            .start()
-    ```
-    
-4. Handling results
-
-    
-    **Default method(Preferred way)**<br>
-    Override `onActivityResult` method and handle ImagePicker result.
-
-    ```kotlin
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-         super.onActivityResult(requestCode, resultCode, data)
-         if (resultCode == Activity.RESULT_OK) {
-             //Image Uri will not be null for RESULT_OK
-             val fileUri = data?.data
-             imgProfile.setImageURI(fileUri)
-          
-            //You can get File object from intent
-            val file:File = ImagePicker.getFile(data)!!
-           
-            //You can also get File Path from intent
-            val filePath:String = ImagePicker.getFilePath(data)!!
-         } else if (resultCode == ImagePicker.RESULT_ERROR) {
-             Toast.makeText(this, ImagePicker.getError(data), Toast.LENGTH_SHORT).show()
-         } else {
-             Toast.makeText(this, "Task Cancelled", Toast.LENGTH_SHORT).show()
-         }
+Usage:
+```kotlin
+private val launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+    if (it.resultCode == Activity.RESULT_OK) {
+        val file = ImagePicker.getFile(it.data)!!
+        mProfileFile = file
+        imgProfile.setLocalImage(file, true)
     }
-    ```
+}
 
-    **Inline method (with InlineActivityResult library, Only Works with FragmentActivity and AppCompatActivity) (Not to be used with crop. See [#32](https://github.com/Dhaval2404/ImagePicker/issues/32))**
-    
-    ```kotlin
+//If you want both Camera and Gallery
+ImagePicker.with(this)
+    //...
+    .createIntentFromDialog { launcher.launch(it) }
+
+//If you want just one option
+launcher.launch(
     ImagePicker.with(this)
-            .compress(1024)         //Final image size will be less than 1 MB(Optional)
-            .maxResultSize(1080, 1080)  //Final image resolution will be less than 1080 x 1080(Optional)
-            .start { resultCode, data ->
-                if (resultCode == Activity.RESULT_OK) {
-                    //Image Uri will not be null for RESULT_OK
-                     val fileUri = data?.data
-                     imgProfile.setImageURI(fileUri)
-                  
-                    //You can get File object from intent
-                    val file:File = ImagePicker.getFile(data)
-                   
-                    //You can also get File Path from intent
-                    val filePath:String = ImagePicker.getFilePath(data)
-                } else if (resultCode == ImagePicker.RESULT_ERROR) {
-                    Toast.makeText(context, ImagePicker.getError(data), Toast.LENGTH_SHORT).show()
-                } else {
-                    Toast.makeText(context, "Task Cancelled", Toast.LENGTH_SHORT).show()
-                }
-            }
-    ```
+        //...
+        .cameraOnly() // or galleryOnly()
+        .createIntent()
+)
+```
 
-# 🎨Customization
+See the original repository README [here](https://github.com/Dhaval2404/ImagePicker)!
 
- *  Pick image using Gallery
+# Changelog
 
-	```kotlin
-	ImagePicker.with(this)
-		.galleryOnly()	//User can only select image from Gallery
-		.start()	//Default Request Code is ImagePicker.REQUEST_CODE
-    ```
+## Fork 1.2.0
+- Removed https://github.com/florent37/InlineActivityResult dependency
 
- *  Capture image using Camera
+---
 
-	```kotlin
-	ImagePicker.with(this)
-		.cameraOnly()	//User can only capture image using Camera
-		.start()
-    ```
- *  Crop image
- 		
-    ```kotlin
-    ImagePicker.with(this)
-		.crop()	    //Crop image and let user choose aspect ratio.
-		.start()
-	```
- *  Crop image with fixed Aspect Ratio
-
-    ```kotlin
-    ImagePicker.with(this)
-		.crop(16f, 9f)	//Crop image with 16:9 aspect ratio
-		.start()
-    ```
- *  Crop square image(e.g for profile)
-
-     ```kotlin
-     ImagePicker.with(this)
-         .cropSquare()	//Crop square image, its same as crop(1f, 1f)
-         .start()
-    ```
- *  Compress image size(e.g image should be maximum 1 MB)
-
-	```kotlin
-    ImagePicker.with(this)
-		.compress(1024)	//Final image size will be less than 1 MB
-		.start()
-    ```
- *  Set Resize image resolution
-
-    ```kotlin
-    ImagePicker.with(this)
-		.maxResultSize(620, 620)	//Final image resolution will be less than 620 x 620
-		.start()
-    ```
- *  Intercept ImageProvider, Can be used for analytics
-
-    ```kotlin
-    ImagePicker.with(this)
-        .setImageProviderInterceptor { imageProvider -> //Intercept ImageProvider
-            Log.d("ImagePicker", "Selected ImageProvider: "+imageProvider.name)
-        }
-        .start()
-    ```
- *  Intercept Dialog dismiss event
-
-	```kotlin
-    ImagePicker.with(this)
-    	.setDismissListener {
-    		// Handle dismiss event
-    		Log.d("ImagePicker", "onDismiss");
-    	}
-    	.start()
-    ```
-
- *  Specify Directory to store captured, cropped or compressed images
-
-    ```kotlin
-    ImagePicker.with(this)
-        //Provide directory path to save images
-        .saveDir(File(Environment.getExternalStorageDirectory(), "ImagePicker"))
-        // .saveDir(Environment.getExternalStorageDirectory())
-        // .saveDir(getExternalFilesDir(null)!!)
-        .start()
-    ```
-
- *  Limit MIME types while choosing a gallery image
-
-    ```kotlin
-    ImagePicker.with(this)
-        .galleryMimeTypes(  //Exclude gif images
-            mimeTypes = arrayOf(
-              "image/png",
-              "image/jpg",
-              "image/jpeg"
-            )
-          )
-        .start()
-    ```
-
- *  You can also specify the request code with ImagePicker
-
-    ```kotlin
-    ImagePicker.with(this)
-		.maxResultSize(620, 620)
-		.start(101)	//Here 101 is request code, you may use this in onActivityResult
-    ```
-
- *  Add Following parameters in your **colors.xml** file, If you want to customize uCrop Activity.
-
-    ```xml
-    <resources>
-        <!-- Here you can add color of your choice  -->
-        <color name="ucrop_color_toolbar">@color/teal_500</color>
-        <color name="ucrop_color_statusbar">@color/teal_700</color>
-        <color name="ucrop_color_widget_active">@color/teal_500</color>
-    </resources>
-    ```
-
-# 💥Compatibility
-
-  * Library - Android Kitkat 4.4+ (API 19)
-  * Sample - Android Kitkat 4.4+ (API 19)
-
-# ✔️Changelog
-
-### Version: 1.8
-
-  * Added dialog dismiss listener (Special Thanks to [kibotu](https://github.com/kibotu))
-  * Added text localization (Special Thanks to [yamin8000](https://github.com/yamin8000) and Jose Bravo)
-  * Fixed crash issue on missing camera app [#69](https://github.com/Dhaval2404/ImagePicker/issues/69)
-  * Fixed issue selecting images from download folder [#86](https://github.com/Dhaval2404/ImagePicker/issues/86)
-  * Fixed exif information lost issue [#121](https://github.com/Dhaval2404/ImagePicker/issues/121)
-  * Fixed crash issue on large image crop [#122](https://github.com/Dhaval2404/ImagePicker/issues/122)
-  * Fixed saving image in cache issue [#127](https://github.com/Dhaval2404/ImagePicker/issues/127)
-
-### Version: 1.7
-
-  * Added option to limit MIME types while choosing a gallery image (Special Thanks to [Marchuck](https://github.com/Marchuck))
-  * Introduced ImageProviderInterceptor, Can be used for analytics (Special Thanks to [Marchuck](https://github.com/Marchuck))
-  * Fixed .crop() opening gallery or camera twice [#32](https://github.com/Dhaval2404/ImagePicker/issues/32)
-  * Fixed FileProvider of the library clashes with the FileProvider of the app [#51](https://github.com/Dhaval2404/ImagePicker/issues/51) (Special Thanks to [OyaCanli](https://github.com/OyaCanli))
-  * Added option to set Storage Directory [#52](https://github.com/Dhaval2404/ImagePicker/issues/52)
-  * Fixed NullPointerException in FileUriUtils.getPathFromRemoteUri()  [#61](https://github.com/Dhaval2404/ImagePicker/issues/61) (Special Thanks to [himphen](https://github.com/himphen))
-  * Fixed UCropActivity Crash Android 4.4 (KiKat) [#82](https://github.com/Dhaval2404/ImagePicker/issues/82)
-  * Fixed PNG image saved as JPG after crop issue [#94](https://github.com/Dhaval2404/ImagePicker/issues/94)
-  * Fixed PNG image saved as JPG after compress issue [#105](https://github.com/Dhaval2404/ImagePicker/issues/105)
-  * Added Polish text translation [#115](https://github.com/Dhaval2404/ImagePicker/issues/115) (Special Thanks to [MarcelKijanka](https://github.com/MarcelKijanka))
-  * Failed to find configured root exception [#116](https://github.com/Dhaval2404/ImagePicker/issues/116)
-
-### Version: 1.6
-
-  * Improved UI/UX of sample app
-  * Removed Bitmap Deprecated Property [#33](https://github.com/Dhaval2404/ImagePicker/issues/33) (Special Thanks to [nauhalf](https://github.com/nauhalf))
-  * Camera opens twice when "Don't keep activities" option is ON [#41](https://github.com/Dhaval2404/ImagePicker/issues/41) (Special Thanks to [benji101](https://github.com/benji101))
-  * Fixed uCrop Crash Issue [#42](https://github.com/Dhaval2404/ImagePicker/issues/42)
-
-### Version: 1.5
-
-  * Fixed app crash issue, due to Camera Permission in manifest [#34](https://github.com/Dhaval2404/ImagePicker/issues/34)
-  * Added Option for Dynamic Crop Ratio. Let User choose aspect ratio [#36](https://github.com/Dhaval2404/ImagePicker/issues/36) (Special Thanks to [Dor-Sloim](https://github.com/Dor-Sloim))
-
-### Version: 1.4
-
-  * Optimized Uri to File Conversion (Inspired by [Flutter ImagePicker](https://github.com/flutter/plugins/tree/master/packages/image_picker))
-  * Removed redundant CAMERA permission [#26](https://github.com/Dhaval2404/ImagePicker/issues/26) (Special Thanks to [PerrchicK](https://github.com/PerrchicK))
-
-### Version: 1.3
-
-  * Sample app made compatible with Android Kitkat 4.4+ (API 19)
-  * Fixed Uri to File Conversion issue [#8](https://github.com/Dhaval2404/ImagePicker/issues/8) (Special Thanks to [squeeish](https://github.com/squeeish))
-
-### Version: 1.2
-
-  * Added Support for Inline Activity Result(Special Thanks to [soareseneves](https://github.com/soareseneves))
-  * Fixed issue [#6](https://github.com/Dhaval2404/ImagePicker/issues/6)
-  
-### Version: 1.1
-
-  * Optimized Compression Logic
-  * Replace white screen with transparent one.
-
-### Version: 1.0
-
-  * Initial Build
-
-## 📃 Libraries Used
-* uCrop [https://github.com/Yalantis/uCrop](https://github.com/Yalantis/uCrop)
-* Compressor [https://github.com/zetbaitsu/Compressor](https://github.com/zetbaitsu/Compressor)
-* InlineActivityResult [https://github.com/florent37/InlineActivityResult](https://github.com/florent37/InlineActivityResult)
-
-### Let us know!
-
-We'll be really happy if you sent us links to your projects where you use our component. Just send an email to **dhavalpatel244@gmail.com** And do let us know if you have any questions or suggestion regarding the library.
-
-## License
-
-    Copyright 2019-2020, Dhaval Patel
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-         http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-    
+## Fork 1.0.0
+- Added [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result)

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.4.30'
     repositories {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         //jcenter plugins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 07 23:33:12 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -1,18 +1,14 @@
 apply plugin: 'com.android.library'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
-
 apply from: "../ktlint.gradle"
 
 android {
-    compileSdkVersion 28
-
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 14
         versionName "1.8"
 
@@ -37,16 +33,17 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation "androidx.exifinterface:exifinterface:1.1.0"
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.activity:activity-ktx:1.2.0'
+    implementation 'androidx.fragment:fragment-ktx:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "androidx.exifinterface:exifinterface:1.3.2"
 
     //More Info: https://github.com/Yalantis/uCrop
     implementation 'com.github.yalantis:ucrop:2.2.6'
@@ -54,9 +51,9 @@ dependencies {
     //More Info: https://github.com/florent37/InlineActivityResult
     compileOnly 'com.github.florent37:inline-activity-result-kotlin:1.0.4'
 
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test:core:1.3.0'
 }
 
 ext {
@@ -72,7 +69,7 @@ ext {
     siteUrl = 'https://github.com/Dhaval2404/ImagePicker/'
     gitUrl = 'https://github.com/Dhaval2404/ImagePicker.git'
 
-    libraryVersion = '1.8'
+    libraryVersion = '1.8.1'
     //If you are uploading new library try : gradlew install
     //If you are updating existing library then execute: gradlew bintrayUpload
     //In both the case don't forgot to put bintray credentials in local.properties file.

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -48,9 +48,6 @@ dependencies {
     //More Info: https://github.com/Yalantis/uCrop
     implementation 'com.github.yalantis:ucrop:2.2.6'
 
-    //More Info: https://github.com/florent37/InlineActivityResult
-    compileOnly 'com.github.florent37:inline-activity-result-kotlin:1.0.4'
-
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test:core:1.3.0'

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePicker.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePicker.kt
@@ -308,6 +308,23 @@ open class ImagePicker {
             }
         }
 
+        fun createIntent(): Intent =
+            Intent(activity, ImagePickerActivity::class.java).apply { putExtras(getBundle()) }
+
+        fun createIntentFromDialog(onResult: (Intent) -> Unit) {
+            if (imageProvider == ImageProvider.BOTH) {
+                DialogHelper.showChooseAppDialog(activity, object : ResultListener<ImageProvider> {
+                    override fun onResult(t: ImageProvider?) {
+                        t?.let {
+                            imageProvider = it
+                            imageProviderInterceptor?.invoke(imageProvider)
+                            onResult(createIntent())
+                        }
+                    }
+                }, dismissListener)
+            }
+        }
+
         /**
          * Pick Image Provider if not specified
          */
@@ -386,8 +403,12 @@ open class ImagePicker {
                 }
             } catch (e: Exception) {
                 if (e is ClassNotFoundException) {
-                    Toast.makeText(if (fragment != null) fragment!!.context else activity, "InlineActivityResult library not installed falling back to default method, please install " +
-                            "it from https://github.com/florent37/InlineActivityResult if you want to get inline activity results.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(
+                        if (fragment != null) fragment!!.context else activity,
+                        "InlineActivityResult library not installed falling back to default method, please install " +
+                                "it from https://github.com/florent37/InlineActivityResult if you want to get inline activity results.",
+                        Toast.LENGTH_LONG
+                    ).show()
                     startActivity(REQUEST_CODE)
                 }
             }

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.result.ActivityResult
 import androidx.core.app.ActivityCompat.requestPermissions
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
@@ -22,7 +23,7 @@ import java.io.File
  * @version 1.0
  * @since 04 January 2019
  */
-class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
+class CameraProvider(activity: ImagePickerActivity,  private val launcher: (Intent) -> Unit) : BaseProvider(activity) {
 
     companion object {
         /**
@@ -44,8 +45,6 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
             Manifest.permission.WRITE_EXTERNAL_STORAGE,
             Manifest.permission.CAMERA
         )
-
-        private const val CAMERA_INTENT_REQ_CODE = 4281
         private const val PERMISSION_INTENT_REQ_CODE = 4282
     }
 
@@ -137,8 +136,7 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
 
         // Check if file exists
         if (file != null && file.exists()) {
-            val cameraIntent = IntentUtils.getCameraIntent(this, file)
-            activity.startActivityForResult(cameraIntent, CAMERA_INTENT_REQ_CODE)
+            launcher.invoke(IntentUtils.getCameraIntent(this, file))
         } else {
             setError(R.string.error_failed_to_create_camera_image_file)
         }
@@ -165,28 +163,12 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         }
     }
 
-    /**
-     * Handle Camera Intent Activity Result
-     *
-     * @param requestCode It must be {@link CameraProvider#CAMERA_INTENT_REQ_CODE}
-     * @param resultCode For success it should be {@link Activity#RESULT_OK}
-     * @param data Result Intent
-     */
-    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == CAMERA_INTENT_REQ_CODE) {
-            if (resultCode == Activity.RESULT_OK) {
-                handleResult(data)
-            } else {
-                setResultCancel()
-            }
+    fun handleResult(result: ActivityResult) {
+        if (result.resultCode == Activity.RESULT_OK) {
+            activity.setImage(mCameraFile!!)
+        } else {
+            setResultCancel()
         }
-    }
-
-    /**
-     * This method will be called when final result fot this provider is enabled.
-     */
-    private fun handleResult(data: Intent?) {
-        activity.setImage(mCameraFile!!)
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/GalleryProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/GalleryProvider.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.result.ActivityResult
 import androidx.core.app.ActivityCompat.requestPermissions
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
@@ -20,7 +21,7 @@ import java.io.File
  * @version 1.0
  * @since 04 January 2019
  */
-class GalleryProvider(activity: ImagePickerActivity) :
+class GalleryProvider(activity: ImagePickerActivity, private val launcher: (Intent) -> Unit) :
     BaseProvider(activity) {
 
     companion object {
@@ -30,8 +31,6 @@ class GalleryProvider(activity: ImagePickerActivity) :
          * same group, we have used write permission here.
          */
         private val REQUIRED_PERMISSIONS = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-
-        private const val GALLERY_INTENT_REQ_CODE = 4261
         private const val PERMISSION_INTENT_REQ_CODE = 4262
     }
 
@@ -40,7 +39,6 @@ class GalleryProvider(activity: ImagePickerActivity) :
 
     init {
         val bundle = activity.intent.extras ?: Bundle()
-
         mimeTypes = bundle.getStringArray(ImagePicker.EXTRA_MIME_TYPES) ?: emptyArray()
     }
 
@@ -68,8 +66,7 @@ class GalleryProvider(activity: ImagePickerActivity) :
      * Start Gallery Intent
      */
     private fun startGalleryIntent() {
-        val galleryIntent = IntentUtils.getGalleryIntent(activity, mimeTypes)
-        activity.startActivityForResult(galleryIntent, GALLERY_INTENT_REQ_CODE)
+        launcher.invoke(IntentUtils.getGalleryIntent(activity, mimeTypes))
     }
 
     /**
@@ -88,20 +85,11 @@ class GalleryProvider(activity: ImagePickerActivity) :
         }
     }
 
-    /**
-     * Handle Camera Intent Activity Result
-     *
-     * @param requestCode It must be {@link CameraProvider#GALLERY_INTENT_REQ_CODE}
-     * @param resultCode For success it should be {@link Activity#RESULT_OK}
-     * @param data Result Intent
-     */
-    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == GALLERY_INTENT_REQ_CODE) {
-            if (resultCode == Activity.RESULT_OK) {
-                handleResult(data)
-            } else {
-                setResultCancel()
-            }
+    fun handleResult(result: ActivityResult) {
+        if (result.resultCode == Activity.RESULT_OK) {
+            handleResult(result.data)
+        } else {
+            setResultCancel()
         }
     }
 

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/util/IntentUtils.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/util/IntentUtils.kt
@@ -62,7 +62,7 @@ object IntentUtils {
     /**
      * @return Intent Camera Intent
      */
-    fun getCameraIntent(context: Context, file: File): Intent? {
+    fun getCameraIntent(context: Context, file: File): Intent {
         val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -73,7 +73,6 @@ object IntentUtils {
         } else {
             intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(file))
         }
-
         return intent
     }
 

--- a/sample/src/main/kotlin/com.github.dhaval2404.imagepicker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com.github.dhaval2404.imagepicker/sample/MainActivity.kt
@@ -9,17 +9,18 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.sample.util.FileUtil
 import com.github.dhaval2404.imagepicker.sample.util.IntentUtil
-import java.io.File
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.content_camera_only.*
 import kotlinx.android.synthetic.main.content_gallery_only.*
 import kotlinx.android.synthetic.main.content_profile.*
+import java.io.File
 
 class MainActivity : AppCompatActivity() {
 
@@ -36,6 +37,15 @@ class MainActivity : AppCompatActivity() {
     private var mGalleryFile: File? = null
     private var mProfileFile: File? = null
 
+    private val launcher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) {
+                val file = ImagePicker.getFile(it.data)!!
+                mProfileFile = file
+                imgProfile.setLocalImage(file, true)
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
         super.onCreate(savedInstanceState)
@@ -49,14 +59,29 @@ class MainActivity : AppCompatActivity() {
         return super.onCreateOptionsMenu(menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
             R.id.action_github -> {
                 IntentUtil.openURL(this, GITHUB_REPOSITORY)
                 return true
             }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    fun pickProfileImageNewApiBoth(view: View) {
+        ImagePicker.with(this)
+            .maxResultSize(512, 512)
+            .createIntentFromDialog { launcher.launch(it) }
+    }
+
+    fun pickProfileImageNewApiOnlyCamera(view: View) {
+        launcher.launch(
+            ImagePicker.with(this)
+                .cameraOnly()
+                .maxResultSize(512, 512)
+                .createIntent()
+        )
     }
 
     fun pickProfileImage(view: View) {
@@ -80,7 +105,6 @@ class MainActivity : AppCompatActivity() {
             .crop()
             // User can only select image from Gallery
             .galleryOnly()
-
             .galleryMimeTypes(  //no gif images at all
                 mimeTypes = arrayOf(
                     "image/png",

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -21,6 +21,13 @@
 
             <include layout="@layout/content_profile" />
 
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_add_new_api"
+                style="@style/FabStyle"
+                android:onClick="pickProfileImageNewApiBoth"
+                app:srcCompat="@drawable/baseline_photo_24"
+                tools:ignore="ContentDescription" />
+
             <include layout="@layout/content_gallery_only" />
 
             <include layout="@layout/content_camera_only" />

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -21,13 +21,6 @@
 
             <include layout="@layout/content_profile" />
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab_add_new_api"
-                style="@style/FabStyle"
-                android:onClick="pickProfileImageNewApiBoth"
-                app:srcCompat="@drawable/baseline_photo_24"
-                tools:ignore="ContentDescription" />
-
             <include layout="@layout/content_gallery_only" />
 
             <include layout="@layout/content_camera_only" />

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     
     <string name="action_camera_only">Camera Only</string>
     <string name="action_gallery_only">Gallery Only</string>
+    <string name="action_all">All with new API</string>
 </resources>


### PR DESCRIPTION
# Changelog

## Fork 1.9.1
- Removed all `startActivityForResult` from library since caller is responsible to provide an `ActivityResultLauncher<Intent>`
- Removed https://github.com/florent37/InlineActivityResult dependency

---

## Fork 1.9.0
- Added [Android Activity Result APIs](https://developer.android.com/training/basics/intents/result)