### PR TITLE
Return intent

### DIFF
--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePicker.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/ImagePicker.kt
@@ -295,6 +295,13 @@ open class ImagePicker {
                 startActivity(reqCode)
             }
         }
+        
+        fun prepareIntent(): Intent {
+            val intent = Intent(activity, ImagePickerActivity::class.java)
+            intent.putExtras(getBundle())
+           
+            return intent
+        }
 
         /**
          * Start Image Picker Activity


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Our ButterknifeController needs to startActivityForResult, and not by passed activity.
So getting the Intent and then starting it "manually" would fix our use case.

## 📄 Motivation and Context
See above: to have more flexibility when using lib 

## 🧪 How Has This Been Tested?
Run startActivityForResult "manually" in calling class.

## 📷 Screenshots (if appropriate)
/

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
