### PR TITLE
changed intent from ACTION_GET_CONTENT to ACTION_GET_CONTENT

### DIFF
--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/util/IntentUtils.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/util/IntentUtils.kt
@@ -40,7 +40,7 @@ object IntentUtils {
      */
     private fun getGalleryDocumentIntent(mimeTypes: Array<String>): Intent {
         // Show Document Intent
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).applyImageTypes(mimeTypes)
+        val intent = Intent(Intent.ACTION_GET_CONTENT).applyImageTypes(mimeTypes)
         intent.addCategory(Intent.CATEGORY_OPENABLE)
         intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)


### PR DESCRIPTION
## 🚀 Description
The current gallery intent only list document app like google drive, file manager etc  but it doesn't list gallery apps like Default gallery, Google photos etc.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This needed to list gallery apps which will make choosing the image easier as user are familiar with gallery apps. The alternative is to traverse directory structure of select image from all the images on device.
More details of the issue are here
https://github.com/Dhaval2404/ImagePicker/issues/263

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Its an intent change and have test on emulator, test devices and personal devices.

## 📷 Screenshots (if appropriate)
<!-- Please provide a screenshot of your change -->
|  ACTION_OPEN_DOCUMENT       |  ACTION_GET_CONTENT       |
| -------------- | -------------- |
| <img src="https://user-images.githubusercontent.com/6481548/140941509-34778387-76df-4341-bc8d-7de14d23bd40.png" width="100%" height="790">   | <img src="https://user-images.githubusercontent.com/6481548/140941550-87cd5635-7710-4dfc-b5fe-d4d3c62cbaf6.png" width="100%" height="790">   |


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
