### PR TITLE
Fixes TransactionTooLargeException #232

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -71,7 +71,8 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      **/
     override fun onSaveInstanceState(outState: Bundle) {
         // Save Camera File
-        outState.putSerializable(STATE_CAMERA_FILE, mCameraFile)
+        //outState.putSerializable(STATE_CAMERA_FILE, mCameraFile.canonicalPath)
+        outState.putString(STATE_CAMERA_FILE, mCameraFile?.canonicalPath)
     }
 
     /**
@@ -79,7 +80,9 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      */
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         // Restore Camera File
-        mCameraFile = savedInstanceState?.getSerializable(STATE_CAMERA_FILE) as File?
+       // mCameraFile = savedInstanceState?.getSerializable(STATE_CAMERA_FILE) as File?
+        val canonicalPath = savedInstanceState?.getString(STATE_CAMERA_FILE) ?: return
+        mCameraFile = getFileDir(canonicalPath)
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.core.app.ActivityCompat.requestPermissions
+import androidx.core.net.toUri
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
 import com.github.dhaval2404.imagepicker.R
@@ -71,7 +72,7 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      **/
     override fun onSaveInstanceState(outState: Bundle) {
         // Save Camera File
-        //outState.putSerializable(STATE_CAMERA_FILE, mCameraFile.canonicalPath)
+        outState.putString(STATE_CAMERA_FILE, mCameraFile?.absolutePath)
     }
 
     /**
@@ -79,7 +80,9 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      */
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         // Restore Camera File
-       // mCameraFile = savedInstanceState?.getSerializable(STATE_CAMERA_FILE) as File?
+        val path = savedInstanceState?.getString(STATE_CAMERA_FILE) ?: return
+        val file = File(path)
+        mCameraFile = file
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -72,7 +72,6 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
     override fun onSaveInstanceState(outState: Bundle) {
         // Save Camera File
         //outState.putSerializable(STATE_CAMERA_FILE, mCameraFile.canonicalPath)
-        outState.putString(STATE_CAMERA_FILE, mCameraFile?.canonicalPath)
     }
 
     /**
@@ -81,8 +80,6 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         // Restore Camera File
        // mCameraFile = savedInstanceState?.getSerializable(STATE_CAMERA_FILE) as File?
-        val canonicalPath = savedInstanceState?.getString(STATE_CAMERA_FILE) ?: return
-        mCameraFile = getFileDir(canonicalPath)
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -6,9 +6,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.core.app.ActivityCompat.requestPermissions
 import androidx.core.net.toFile
-import androidx.core.net.toUri
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
 import com.github.dhaval2404.imagepicker.R
@@ -39,6 +39,7 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
             Manifest.permission.CAMERA
         )
 
+        val TAG = "Hello"
         private const val CAMERA_INTENT_REQ_CODE = 4281
         private const val PERMISSION_INTENT_REQ_CODE = 4282
     }
@@ -73,7 +74,9 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      **/
     override fun onSaveInstanceState(outState: Bundle) {
         // Save Camera File
-        outState.putParcelable(STATE_CAMERA_FILE, Uri.fromFile(mCameraFile))
+        if(mCameraFile != null) {
+            outState.putParcelable(STATE_CAMERA_FILE, Uri.fromFile(mCameraFile))
+        }
     }
 
     /**
@@ -83,14 +86,20 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
         // Restore Camera File
         val uri : Uri = savedInstanceState?.getParcelable(STATE_CAMERA_FILE) ?: return
         mCameraFile = uri.toFile()
+        Log.d(TAG, "mCamera file after onRestoreInstanceState: $mCameraFile")
     }
 
-    /**
+    /**r
      * Start Camera Intent
      *
      * Create Temporary File object and Pass it to Camera Intent
      */
     fun startIntent() {
+        if(mCameraFile != null) {
+            handleResult()
+            return
+        }
+
         if (!IntentUtils.isCameraAppAvailable(this)) {
             setError(R.string.error_camera_app_not_found)
             return

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CameraProvider.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.core.app.ActivityCompat.requestPermissions
+import androidx.core.net.toFile
 import androidx.core.net.toUri
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
@@ -72,7 +73,7 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      **/
     override fun onSaveInstanceState(outState: Bundle) {
         // Save Camera File
-        outState.putString(STATE_CAMERA_FILE, mCameraFile?.absolutePath)
+        outState.putParcelable(STATE_CAMERA_FILE, Uri.fromFile(mCameraFile))
     }
 
     /**
@@ -80,9 +81,8 @@ class CameraProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      */
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         // Restore Camera File
-        val path = savedInstanceState?.getString(STATE_CAMERA_FILE) ?: return
-        val file = File(path)
-        mCameraFile = file
+        val uri : Uri = savedInstanceState?.getParcelable(STATE_CAMERA_FILE) ?: return
+        mCameraFile = uri.toFile()
     }
 
     /**

--- a/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
+++ b/imagepicker/src/main/kotlin/com/github/dhaval2404/imagepicker/provider/CropProvider.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import androidx.core.net.toFile
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.ImagePickerActivity
 import com.github.dhaval2404.imagepicker.R
@@ -70,7 +71,9 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
      */
     override fun onSaveInstanceState(outState: Bundle) {
         // Save crop file
-        outState.putSerializable(STATE_CROP_FILE, mCropImageFile)
+        if(mCropImageFile != null) {
+            outState.putParcelable(STATE_CROP_FILE, Uri.fromFile(mCropImageFile))
+        }
     }
 
     /**
@@ -79,6 +82,9 @@ class CropProvider(activity: ImagePickerActivity) : BaseProvider(activity) {
     override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
         // Restore crop file
         mCropImageFile = savedInstanceState?.getSerializable(STATE_CROP_FILE) as File?
+
+        val uri : Uri = savedInstanceState?.getParcelable(STATE_CROP_FILE) ?: return
+        mCropImageFile = uri.toFile()
     }
 
     /**

--- a/sample/src/main/kotlin/com.github.dhaval2404.imagepicker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com.github.dhaval2404.imagepicker/sample/MainActivity.kt
@@ -125,6 +125,7 @@ class MainActivity : AppCompatActivity() {
         ImagePicker.with(this)
             // User can only capture image from Camera
             .cameraOnly()
+            .crop()
             // Image size will be less than 1024 KB
             // .compress(1024)
             //  Path: /storage/sdcard0/Android/data/package/files


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Fixes Issue TransactionTooLargeException #232. This exception happens because mCameraFile and mCropImageFile is stored as file in the bundle. To solve instead of storing file, just store the uri of the file.

## 📄 Motivation and Context
This change is require to solve the open issue TransactionTooLargeException #232.

## 🧪 How Has This Been Tested?
The test was done manually through capturing a photo that might take at least > 1mb.


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
